### PR TITLE
FB Pixel Donate and Purchase events now fire from Receipt pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+-   FB Pixel Donate and Purchase events now fire from Receipt pages (#10)
+
 ### Changed
 
 -   Facebook Pixel Tracking add-on now uses the add-on boilerplate (#8)

--- a/src/FacebookPixel/Assets.php
+++ b/src/FacebookPixel/Assets.php
@@ -59,8 +59,8 @@ class Assets {
 				true
 			);
 
-			$session    = new DonationAccessor();
-			$donation 	= new Donation( $session->getDonationId() );
+			$session	= new DonationAccessor();
+			$donation	= new Donation( $session->getDonationId() );
 
 			$localized_data = [
 				'currency' 	=> $donation->currency,

--- a/src/FacebookPixel/Assets.php
+++ b/src/FacebookPixel/Assets.php
@@ -60,11 +60,11 @@ class Assets {
 			);
 
 			$session    = new DonationAccessor();
-			$donation = new Donation( $session->getDonationId() );
+			$donation 	= new Donation( $session->getDonationId() );
 
 			$localized_data = [
-				'currency' => $donation->currency,
-				'amount' => $donation->total,
+				'currency' 	=> $donation->currency,
+				'amount' 	=> $donation->total,
 			];
 
 			wp_localize_script( 'give-fbpt-script-frontend', 'giveFBPT', $localized_data );

--- a/src/FacebookPixel/Assets.php
+++ b/src/FacebookPixel/Assets.php
@@ -2,6 +2,8 @@
 namespace GiveFBPT\FacebookPixel;
 
 use \Give\Helpers\Form\Utils as FormUtils;
+use \Give\Session\SessionDonation\DonationAccessor;
+use \Give_Payment as Donation;
 
 /**
  * Helper class responsible for loading add-on assets.
@@ -56,6 +58,17 @@ class Assets {
 				GIVE_FBPT_VERSION,
 				true
 			);
+
+			$session    = new DonationAccessor();
+			$donation = new Donation( $session->getDonationId() );
+
+			$localized_data = [
+				'currency' => $donation->currency,
+				'amount' => $donation->total,
+			];
+
+			wp_localize_script( 'give-fbpt-script-frontend', 'giveFBPT', $localized_data );
+
 		}
 	}
 }

--- a/src/FacebookPixel/resources/js/frontend/give-fbpt.js
+++ b/src/FacebookPixel/resources/js/frontend/give-fbpt.js
@@ -2,7 +2,6 @@ const { fbq } = window.parent ? window.parent : window;
 const { giveFBPT } = window;
 
 if (typeof fbq !== "undefined") { 
-    console.log('fbq event!!', giveFBPT);
     fbq('track', 'Donate' );
     fbq('track', 'Purchase', {currency: giveFBPT.currency, value: giveFBPT.amount});
 }

--- a/src/FacebookPixel/resources/js/frontend/give-fbpt.js
+++ b/src/FacebookPixel/resources/js/frontend/give-fbpt.js
@@ -1,4 +1,4 @@
-const { fbq } = window.parent ? window.parent : window;
+const { fbq } = window.parent ?? window;
 const { giveFBPT } = window;
 
 if (typeof fbq === "function") { 

--- a/src/FacebookPixel/resources/js/frontend/give-fbpt.js
+++ b/src/FacebookPixel/resources/js/frontend/give-fbpt.js
@@ -2,6 +2,7 @@ const { fbq } = window.parent ? window.parent : window;
 const { giveFBPT } = window;
 
 if (typeof fbq !== "undefined") { 
+    console.log('fbq event!!', giveFBPT);
     fbq('track', 'Donate' );
-    fbq('track', 'Purchase', {currency: giveFBPT.currency, value: giveFBPT.amount}),
+    fbq('track', 'Purchase', {currency: giveFBPT.currency, value: giveFBPT.amount});
 }

--- a/src/FacebookPixel/resources/js/frontend/give-fbpt.js
+++ b/src/FacebookPixel/resources/js/frontend/give-fbpt.js
@@ -1,12 +1,7 @@
-console.log('FBPT script loaded!');
-if (typeof window.fbq !== "undefined") { 
-    console.log('An FB Pixel was detected! The GiveWP Donation Pixel can now fire!');
-    // const form = document.querySelector('form[id*="give-form"]');
-    // const amount = document.querySelector('.give-final-total-amount');
-    // var donateclick = document.getElementById("give-purchase-button");
-    
-    // donateclick.onclick(
-    //     fbq('track', 'Purchase', {currency: form.dataset.currency_code, value: amount}),
-    //     console.log('The GiveWP Pixel fired with a value of:' + form.dataset.currency_code + ' ' + amount)
-    // );
+const { fbq } = window.parent ? window.parent : window;
+const { giveFBPT } = window;
+
+if (typeof fbq !== "undefined") { 
+    fbq('track', 'Donate' );
+    fbq('track', 'Purchase', {currency: giveFBPT.currency, value: giveFBPT.amount}),
 }

--- a/src/FacebookPixel/resources/js/frontend/give-fbpt.js
+++ b/src/FacebookPixel/resources/js/frontend/give-fbpt.js
@@ -1,7 +1,7 @@
 const { fbq } = window.parent ? window.parent : window;
 const { giveFBPT } = window;
 
-if (typeof fbq !== "undefined") { 
+if (typeof fbq === "function") { 
     fbq('track', 'Donate' );
     fbq('track', 'Purchase', {currency: giveFBPT.currency, value: giveFBPT.amount});
 }


### PR DESCRIPTION
Resolves #6 

## Description
This PR introduces logic to fire Donate and Purchase Facebook Pixel events when the Receipt page is reached (either inside the Multi-Step Form or Legacy Form).  Specifically, it introduces logic to fire the "Donate" and "Purchase" events.

## Affects
This PR affects frontend scripts and how that script is enqueued. 

## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changelog updated
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions
1. Install Official Facebook Pixel plugin, and setup a FB Pixel
2. Install FB Pixel Helper Chrome extension (for debugging)
3. Create new Multi-Step Form
4. Create new Legacy Form
5. Complete donations in each form
6. Check that on the confirmation/receipt page an FB Pixel event was fired (visible in the FB Pixel Helper extension)