### PR TITLE
FB Pixel Complete Registration event now fires on new user registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 -   FB Pixel Donate and Purchase events now fire from Receipt pages (#10)
+-   FB Pixel Complete Registration event now fires on new user registration (#12)
 
 ### Changed
 

--- a/src/FacebookPixel/Assets.php
+++ b/src/FacebookPixel/Assets.php
@@ -59,10 +59,16 @@ class Assets {
 				true
 			);
 
-			$session	= new DonationAccessor();
-			$donation	= new Donation( $session->getDonationId() );
+			$purchase = Give()->session->get('give_purchase');
+
+			if ( isset( $purchase['post_data']['give_create_account'] ) && $purchase['post_data']['give_create_account'] === 'on' ) {
+				$isNewRegistration = true;
+			}
+
+			$donation	= new Donation( $purchase['donation_id'] );
 
 			$localized_data = [
+				'isNewRegistration' => $isNewRegistration,
 				'currency' 	=> $donation->currency,
 				'amount' 	=> $donation->total,
 			];

--- a/src/FacebookPixel/Assets.php
+++ b/src/FacebookPixel/Assets.php
@@ -62,6 +62,8 @@ class Assets {
 
 			if ( isset( $purchase['post_data']['give_create_account'] ) && $purchase['post_data']['give_create_account'] === 'on' ) {
 				$isNewRegistration = true;
+			} else {
+				$isNewRegistration = false;
 			}
 
 			$donation	= new Donation( $purchase['donation_id'] );

--- a/src/FacebookPixel/Assets.php
+++ b/src/FacebookPixel/Assets.php
@@ -72,6 +72,7 @@ class Assets {
 				'isNewRegistration' => $isNewRegistration,
 				'currency' 	=> $donation->currency,
 				'amount' 	=> $donation->total,
+				'status' => $donation->status,
 			];
 
 			wp_localize_script( 'give-fbpt-script-frontend', 'giveFBPT', $localized_data );

--- a/src/FacebookPixel/Assets.php
+++ b/src/FacebookPixel/Assets.php
@@ -2,7 +2,6 @@
 namespace GiveFBPT\FacebookPixel;
 
 use \Give\Helpers\Form\Utils as FormUtils;
-use \Give\Session\SessionDonation\DonationAccessor;
 use \Give_Payment as Donation;
 
 /**

--- a/src/FacebookPixel/SettingsPage.php
+++ b/src/FacebookPixel/SettingsPage.php
@@ -17,7 +17,7 @@ class SettingsPage extends \Give_Settings_Page {
 	 */
 	public function __construct() {
 		$this->id          = 'give-fbpt';
-		$this->label       = esc_html__( 'GIVE_FBPT Setting ', 'GIVE_FBPT' );
+		$this->label       = esc_html__( 'Facebook Pixel Tracking', 'GIVE_FBPT' );
 		$this->default_tab = 'text_fields';
 
 		parent::__construct();

--- a/src/FacebookPixel/resources/js/frontend/give-fbpt.js
+++ b/src/FacebookPixel/resources/js/frontend/give-fbpt.js
@@ -4,4 +4,5 @@ const { giveFBPT } = window;
 if (typeof fbq === "function") { 
     fbq('track', 'Donate' );
     fbq('track', 'Purchase', {currency: giveFBPT.currency, value: giveFBPT.amount});
+    giveFBPT.isNewRegistration && fbq('track', 'CompleteRegistration');
 }

--- a/src/FacebookPixel/resources/js/frontend/give-fbpt.js
+++ b/src/FacebookPixel/resources/js/frontend/give-fbpt.js
@@ -1,7 +1,7 @@
 const { fbq } = window.parent ?? window;
 const { giveFBPT } = window;
 
-if (typeof fbq === "function") { 
+if (typeof fbq === "function" && giveFBPT.status === 'publish') { 
     fbq('track', 'Donate' );
     fbq('track', 'Purchase', {currency: giveFBPT.currency, value: giveFBPT.amount});
     giveFBPT.isNewRegistration && fbq('track', 'CompleteRegistration');


### PR DESCRIPTION
Resolves #11

## Description
This PR introduces logic to ensure that a "CompleteRegistration" event is fired when new user registration occurs. The event is fired from the receipt page for both legacy forms and the multi-step form. 

## Affects
This PR affects the data localized for use with FBPT frontend scripts, using the global Give session to check if a new user registration occured as part of the donation process.

## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changelog updated
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

1. Install the FB Pixel Helper Chrome extension to check what FB pixel events are fired
2. Logout, and view a form from the frontend
3. Complete your donation, and check "Create a new account"
4. On the receipt page, open FB Pixel Helper to check that a "CompleteRegistration" event was fired correctly