### PR TITLE
Add a link to the FB pixel installation guide

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -62,7 +62,10 @@ Automatic updates should work like a charm; as always though, ensure you backup 
 
 = How do I install the Facebook Pixel on my website? = 
 
-There are many ways to do that. Here's [a few plugins that can help](https://wordpress.org/plugins/search/facebook+pixel/).
+There are many ways to do that:
+
+* Here's [a few plugins that can help](https://wordpress.org/plugins/search/facebook+pixel/). 
+* Here's [a detailed guide from Facebook on how to install and test your pixel](https://www.facebook.com/business/m/pixel-platform-install/).
 
 It is important to understand that this plugin only works if the Facebook Pixel is already installed on your website. This extends your pixel to include the donation activity coming from your GiveWP forms. 
 

--- a/src/FacebookPixel/SettingsPage.php
+++ b/src/FacebookPixel/SettingsPage.php
@@ -49,6 +49,12 @@ class SettingsPage extends \Give_Settings_Page {
 			</ul>
 
 			<p><a href="https://developers.facebook.com/docs/facebook-pixel/reference" target="_blank" rel="noopener"><?php _e('You can learn more about these events here.', 'GIVE_FBPT'); ?></a></p>
+			
+			<hr />
+			<p><strong><?php _e('Haven\'t yet installed the Facebook pixel on your website?', 'GIVE_FBPT'); ?></strong></p>
+			<p>
+				<?php printf(esc_html('See %1$sFacebook\'s detailed guide here%2$s.', 'GIVE_FBPT'), '<a href="https://www.facebook.com/business/m/pixel-platform-install/" target="_blank" rel="noopener">','</a>'); ?>
+			</p>
 
 			<h3><?php _e('Troubleshooting the Facebook Pixel', 'GIVE_FBPT'); ?></h3>
 			<p><?php printf(esc_html('The best way to confirm that these events are firing on your donation confirmation panel correctly is to use the %1$sFacebook Pixel Helper Chrome Extension%2$s.', 'GIVE_FBPT'),'<a href="https://www.facebook.com/business/help/198406697184603?id=1205376682832142" target="_blank" rel="noopener">', '</a>'); ?></p>


### PR DESCRIPTION
## Description

We're already getting confused users for this addon. Let's reinforce the need to install the pixel with a call out in the readme and the plugin docs to the official FB pixel installation guide.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->
New users wanting to install this addon.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->
![image](https://user-images.githubusercontent.com/930724/99014772-3ee39380-2508-11eb-855d-c9a03fc62767.png)